### PR TITLE
Fix conda handler for main channel packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2025-01-06
+
+### Fixed
+- Conda handler now correctly resolves download URLs for packages from the 'main' channel
+  - Main/defaults channels now use repo.anaconda.com/pkgs/main/ URL structure
+  - Community channels (conda-forge, bioconda) continue using anaconda.org URL structure
+- Resolved issue where main channel packages were failing with "Failed to resolve download URL" error
+
 ## [0.1.1] - 2025-01-27
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "semantic-copycat-purl2src"
-version = "0.1.1"
+version = "1.1.2"
 description = "Translate Package URLs (PURLs) into validated download URLs for source code artifacts"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/purl2src/handlers/conda.py
+++ b/src/purl2src/handlers/conda.py
@@ -8,49 +8,60 @@ from .base import BaseHandler, HandlerError
 
 class CondaHandler(BaseHandler):
     """Handler for Conda packages."""
-    
+
     def build_download_url(self, purl: Purl) -> Optional[str]:
         """
         Build Conda download URL.
-        
+
         Requires qualifiers: build, channel, subdir
-        Format: https://anaconda.org/{channel}/{package}/{version}/download/{subdir}/{package}-{version}-{build}.tar.bz2
+        Format depends on channel:
+        - main/defaults: repo.anaconda.com/pkgs/main/{subdir}/{pkg}-{ver}-{build}.tar.bz2
+        - others: anaconda.org/{ch}/{pkg}/{ver}/download/{subdir}/{pkg}-{ver}-{build}.tar.bz2
         """
         if not purl.version:
             return None
-        
+
         # Check required qualifiers
         required = ["build", "channel", "subdir"]
         for qual in required:
             if qual not in purl.qualifiers:
                 raise HandlerError(f"Missing required qualifier: {qual}")
-        
+
         build = purl.qualifiers["build"]
         channel = purl.qualifiers["channel"]
         subdir = purl.qualifiers["subdir"]
-        
-        return (
-            f"https://anaconda.org/{channel}/{purl.name}/{purl.version}/"
-            f"download/{subdir}/{purl.name}-{purl.version}-{build}.tar.bz2"
-        )
-    
+
+        # Handle different channel types
+        if channel in ["main", "defaults"]:
+            # Main/defaults channel uses repo.anaconda.com
+            return (
+                f"https://repo.anaconda.com/pkgs/main/{subdir}/"
+                f"{purl.name}-{purl.version}-{build}.tar.bz2"
+            )
+        else:
+            # Community channels (conda-forge, bioconda, etc.) use anaconda.org
+            return (
+                f"https://anaconda.org/{channel}/{purl.name}/{purl.version}/"
+                f"download/{subdir}/{purl.name}-{purl.version}-{build}.tar.bz2"
+            )
+
     def get_download_url_from_api(self, purl: Purl) -> Optional[str]:
         """Query Anaconda API."""
         # Could implement Anaconda API query here
         return None
-    
+
     def get_fallback_cmd(self, purl: Purl) -> Optional[str]:
         """Get conda command."""
         if not purl.version:
             return None
-        
+
         channel = purl.qualifiers.get("channel", "conda-forge")
         return f"conda search -c {channel} {purl.name}={purl.version} --info"
-    
+
     def get_package_manager_cmd(self) -> List[str]:
         """Conda command names."""
         return ["conda", "mamba", "micromamba"]
-    
+
     def parse_fallback_output(self, output: str) -> Optional[str]:
         """Parse conda search output."""
         # Look for "url :" line


### PR DESCRIPTION
## Summary
- Fixed URL resolution for conda packages from the main/defaults channel
- Main channel packages now correctly use `repo.anaconda.com/pkgs/main/` URL structure
- Community channels (conda-forge, bioconda) continue using `anaconda.org` as before

## Details
The conda handler was incorrectly using the anaconda.org URL pattern for all channels. However, the main/defaults channel packages are hosted at repo.anaconda.com with a different URL structure.

This PR updates the handler to:
1. Check if the channel is "main" or "defaults"
2. Use the appropriate URL pattern based on the channel type

## Test Results
```bash
# Main channel - now works correctly
$ purl2src "pkg:conda/python@3.9.7?build=h12debd9_1&channel=main&subdir=linux-64"
pkg:conda/python@3.9.7?build=h12debd9_1&channel=main&subdir=linux-64 -> https://repo.anaconda.com/pkgs/main/linux-64/python-3.9.7-h12debd9_1.tar.bz2

# Conda-forge - continues to work as before  
$ purl2src "pkg:conda/absl-py@1.3.0?build=pyhd8ed1ab_0&channel=conda-forge&subdir=noarch"
pkg:conda/absl-py@1.3.0?build=pyhd8ed1ab_0&channel=conda-forge&subdir=noarch -> https://anaconda.org/conda-forge/absl-py/1.3.0/download/noarch/absl-py-1.3.0-pyhd8ed1ab_0.tar.bz2
```

## Version
Bumped to 1.1.2 with changelog entry

Fixes #1